### PR TITLE
fix: parse json response with jq

### DIFF
--- a/.beth.sh
+++ b/.beth.sh
@@ -2,6 +2,10 @@ if [ ! -x "$(command -v curl)" ]; then
     echo "Please install curl to use this script." && return
 fi
 
+if [ ! -x "$(command -v jq)" ]; then
+    echo "Please install jq to use this script." && return
+fi
+
 DEFAULT_ETH_RPC_URL="https://cloudflare-eth.com"
 
 if [ -z "${ETH_RPC_URL}" ]; then
@@ -249,7 +253,7 @@ __request_call() {
 
 __parse_result() {
     if test "${1#*result}" != "${1}"; then
-        echo "$(sed -e 's/.*"result": *\(.*\)}.*/\1/' <<<"${1}")"
+        echo "$(echo "${1}" | jq .result)"
     else
         echo "$1"
         return 1

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Supported are read-only RPCs, excluding filters, tx signing and that kind of stu
 
 ## Installation
 
-The only dependency is `curl` and some fairly widespread UNIX tools. Just do
+The dependencies are `curl` and `jq`, some fairly widespread UNIX tools. Just do
 
 #### Bash
 


### PR DESCRIPTION
The RPC response might be:

```
{
    "result": "xxx"
}

{
    "result": "xxx",
    "id": 1234
}

{
    "result": {
        // xxx
    }
}
...
```
The parse result didn't work sometimes, in this PR I fix this with `jq` tool.